### PR TITLE
Laravel 9 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "beecoded/mongodb-session",
+    "name": "jenssegers/mongodb-session",
     "description": "A MongoDB session driver for Laravel 4, 5, 6, 7, 8 and 9",
     "keywords": ["laravel","session","mongodb","mongo","driver"],
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "jenssegers/mongodb-session",
-    "description": "A MongoDB session driver for Laravel 4, 5, 6, 7 and 8",
+    "name": "beecoded/mongodb-session",
+    "description": "A MongoDB session driver for Laravel 4, 5, 6, 7, 8 and 9",
     "keywords": ["laravel","session","mongodb","mongo","driver"],
     "authors": [
         {
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=7.2",
         "jenssegers/mongodb": "*",
-        "illuminate/session": "~4.0|~5.0|~6.0|~7.0|~8.0"
+        "illuminate/session": "~4.0|~5.0|~6.0|~7.0|~8.0|~9.0"
     },
     "autoload": {
         "psr-0": {

--- a/src/Jenssegers/Mongodb/Session/SessionManager.php
+++ b/src/Jenssegers/Mongodb/Session/SessionManager.php
@@ -26,7 +26,7 @@ class SessionManager extends \Illuminate\Support\Manager
 
         $handler = new MongoDbSessionHandler($connection->getMongoClient(), $this->getMongoDBOptions($database, $collection));
 
-        $handler->open(null, 'mongodb');
+        $handler->open('', 'mongodb');
 
         return $handler;
     }


### PR DESCRIPTION
Changes the call to MongoDbSessionHandler::open()'s first parameter to a blank string instead of null, since Laravel 9's static typing implementation.